### PR TITLE
Add bidi support to bio and description

### DIFF
--- a/src/site/sass/main.sass
+++ b/src/site/sass/main.sass
@@ -86,6 +86,9 @@ body
 			font-size: 20px
 			font-weight: normal
 
+		.bio
+			unicode-bidi: plaintext
+
 		.profile-counter
 			line-height: 1.3
 
@@ -273,7 +276,8 @@ body
 			overflow-wrap: anywhere
 			font-size: 20px
 			line-height: 1.4
-
+			unicode-bidi: plaintext
+                        
 			@media screen and (max-width: $layout-a-max)
 				font-size: 18px
 


### PR DESCRIPTION
Regarding #33, the bidi support for post description as well as bio.

I have tested locally with Firefox and it works perfectly fine.

![image](https://user-images.githubusercontent.com/11241315/75118245-1116a000-5696-11ea-84d8-78b0bbf27ab6.png)
